### PR TITLE
populate `environment` in Rollbar reports from Jets

### DIFF
--- a/lib/rollbar_jets/turbine.rb
+++ b/lib/rollbar_jets/turbine.rb
@@ -5,6 +5,7 @@ module RollbarJets
     initializer 'rollbar.configure' do
       Rollbar.configure do |config|
         config.access_token = ENV["ROLLBAR_ACCESS_TOKEN"]
+        config.environment = ENV["JETS_ENV"]
       end
     end
 


### PR DESCRIPTION
This will populate the `environment` in Rollbar reports. Helpful to filter alerts for production errors, etc.

I wasn't sure if you wanted me to bump the gem for release or anything else. Thanks for making this! I was happy to find that 99% of the work to integrate Rollbar was already done!